### PR TITLE
ITGMania lights support while in gamepad mode

### DIFF
--- a/descriptors/hid_desc.h
+++ b/descriptors/hid_desc.h
@@ -110,6 +110,15 @@ static const uint8_t hid_report_descriptor[] =
     // 0x0a, 0x21, 0x26,  //   Unknown
     // 0x95, 0x08,        //   REPORT_COUNT (8)
     // 0xb1, 0x02,        //   FEATURE (Data,Var,Abs)
+    
+    // 16-byte output report for lights
+    0x09, 0x00,        //   USAGE (Undefined)
+    0x15, 0x00,        //   LOGICAL_MINIMUM (0)
+    0x26, 0xff, 0x00,  //   LOGICAL_MAXIMUM (255)
+    0x75, 0x08,        //   REPORT_SIZE (8)
+    0x95, 0x10,        //   REPORT_COUNT (16)
+    0x91, 0x02,        //   OUTPUT (Data,Var,Abs)
+
     0xc0               // END_COLLECTION
 };
 

--- a/main.c
+++ b/main.c
@@ -329,7 +329,7 @@ void lights_task() {
         SETORCLRBIT(buf, LATCH_CABL_NEON, lights.bass_light);
 
         SETBIT(buf, LATCH_ALWAYS_ON);
-        // CLRBIT(buf, LATCH_COIN_COUNTER);
+        SETORCLRBIT(buf, LATCH_COIN_COUNTER, lights.coin_pulse);
         SETBIT(buf, LATCH_JAMMA_LED);
     } else {
         SETORCLRBIT(buf, LATCH_P1L_UPLEFT, lights.p1_ul_light);
@@ -356,7 +356,7 @@ void lights_task() {
         SETORCLRBIT(buf, LATCH_CABL_NEON, lights.bass_light);
 
         SETBIT(buf, LATCH_ALWAYS_ON);
-        // CLRBIT(buf, LATCH_COIN_COUNTER);
+        SETORCLRBIT(buf, LATCH_COIN_COUNTER, lights.coin_pulse);
         SETBIT(buf, LATCH_JAMMA_LED);
     }
 

--- a/main.c
+++ b/main.c
@@ -687,6 +687,8 @@ void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_
             lxio_set_report(buffer, bufsize, &lights);
         } else if (input_mode == INPUT_MODE_GAMECUBE) {
             // rumble
+        } else if (input_mode == INPUT_MODE_GAMEPAD) {
+            hid_set_report(buffer, bufsize, &lights);
         }
     }
 }

--- a/piuio_structs.h
+++ b/piuio_structs.h
@@ -83,7 +83,9 @@ struct lightsArray {
             uint8_t r1_halo : 1;
             uint8_t l2_halo : 1;
             uint8_t l1_halo : 1;
-            uint8_t empty5 : 3;
+            uint8_t empty4 : 1;
+            uint8_t coin_pulse : 1;
+            uint8_t empty5 : 1;
             uint8_t r1_halo_dupe : 1;
             uint8_t r2_halo_dupe : 1;
 

--- a/reports/hid_report.h
+++ b/reports/hid_report.h
@@ -155,4 +155,63 @@ uint16_t hid_get_report(HIDReport** report, struct inputArray* input) {
     return sizeof(HIDReport);
 }
 
+typedef struct __attribute((packed, aligned(1)))
+{
+    union {
+        uint8_t data[16];
+        struct {
+            uint8_t p1_ul_light;
+            uint8_t p1_ur_light;
+            uint8_t p1_cn_light;
+            uint8_t p1_dl_light;
+            uint8_t p1_dr_light;
+
+            uint8_t p2_ul_light;
+            uint8_t p2_ur_light;
+            uint8_t p2_cn_light;
+            uint8_t p2_dl_light;
+            uint8_t p2_dr_light;
+
+            uint8_t bass_light;
+
+            uint8_t l1_halo; // Marquee UL
+            uint8_t l2_halo; // Marquee UR
+            uint8_t r1_halo; // Marquee DL
+            uint8_t r2_halo; // Marquee DR
+            
+            uint8_t coin_pulse;
+        };
+    };
+} HIDOutputReport;
+
+static HIDOutputReport hidOutputReport = {
+    .data = {0x00}
+};
+
+void hid_set_report(const uint8_t* buffer, uint16_t bufsize, struct lightsArray* lights) {
+    if (bufsize == 16) {
+        memcpy(hidOutputReport.data, buffer, bufsize);
+
+        lights->p1_ul_light = hidOutputReport.p1_ul_light;
+        lights->p1_ur_light = hidOutputReport.p1_ur_light;
+        lights->p1_cn_light = hidOutputReport.p1_cn_light;
+        lights->p1_dl_light = hidOutputReport.p1_dl_light;
+        lights->p1_dr_light = hidOutputReport.p1_dr_light;
+
+        lights->p2_ul_light = hidOutputReport.p2_ul_light;
+        lights->p2_ur_light = hidOutputReport.p2_ur_light;
+        lights->p2_cn_light = hidOutputReport.p2_cn_light;
+        lights->p2_dl_light = hidOutputReport.p2_dl_light;
+        lights->p2_dr_light = hidOutputReport.p2_dr_light;
+
+        lights->bass_light = hidOutputReport.bass_light;
+        lights->coin_pulse = hidOutputReport.coin_pulse;
+
+        lights->l1_halo = hidOutputReport.l1_halo;
+        lights->l2_halo = hidOutputReport.l2_halo;
+        lights->r1_halo = hidOutputReport.r1_halo;
+        lights->r2_halo = hidOutputReport.r2_halo;
+    }
+}
+
 #endif

--- a/reports/lxio_report.h
+++ b/reports/lxio_report.h
@@ -266,6 +266,7 @@ void lxio_set_report(uint8_t const* buffer, uint16_t bufsize, struct lightsArray
     lights->r1_halo = lxioOutputReport.r1_halo;
     lights->r2_halo = lxioOutputReport.r2_halo;
     lights->bass_light = lxioOutputReport.bass_light;
+    lights->coin_pulse = lxioOutputReport.p1_coin_cnt;
 }
 
 #endif


### PR DESCRIPTION
This adds support for lights while the BrokeIO card is in gamepad mode.
I've tested this working with local ITGMania changes (https://github.com/itgmania/itgmania/pull/1448) in "dance" gamemode.

I also noticed that, when inserting a coin, the mechanical coin counter did not increment (which is controlled by a bit in the lights array).
The coin counter will now increment by one whenever the game instructs the BrokeIO to.

Confirmed working in the following scenarios:
1. Stock ITG (R16), PIUIO mode
2. Din's ITGMania system image, PIUIO mode
3. Din's ITGMania system image, LXIO mode
4. Din's ITGMania system image, gamepad mode (with local ITGMania changes)